### PR TITLE
Release chart on tags instead of master branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,9 @@ name: Release Charts
 
 on:
   push:
-    branches:
-    - master
-    paths:
-    - 'charts/soveren-agent/Chart.yaml'
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-[a-z]+.[0-9]+'
 
 jobs:
   release:
@@ -15,6 +14,20 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    
+    - name: Check that the git tag matches the chart version
+      run: |
+        CHART_VERSION=$(yq .version charts/soveren-agent/Chart.yaml)
+        if [[ "${GITHUB_REF_NAME}" == "${CHART_VERSION}" ]]; then
+          echo "Git tag: ${GITHUB_REF_NAME}"
+          echo "Chart version: ${CHART_VERSION}"
+          echo "OK: Git tag matches chart version"
+        else
+          echo "Git tag: ${GITHUB_REF_NAME}"
+          echo "Chart version: ${CHART_VERSION}"
+          echo "ERROR: Git tag and chart version are different"
+          exit 1
+        fi
 
     - name: Configure Git
       run: |


### PR DESCRIPTION
Release chart on tags like `0.1.0`, `0.1.0-rc.1`, `0.1.0-alpha.52`. Check if chart version identical to tag name.